### PR TITLE
Serializationrework

### DIFF
--- a/scripts/generate_serialization.py
+++ b/scripts/generate_serialization.py
@@ -216,7 +216,7 @@ for entry in file_list:
 
             class_serialize = ''
             class_serialize += base_serialize.replace('${BASE_CLASS_NAME}', base_class_name)
-            class_deserialize = f'\tauto result = make_uniq<{class_name}>({constructor_parameters});\n'
+            class_deserialize = f'\tauto result = duckdb::unique_ptr<{class_name}>(new {class_name}({constructor_parameters}));\n'
             for entry in serialize_data[class_name]:
                 property_name = entry['property'] if 'property' in entry else entry['name']
                 property_key = entry['name']

--- a/src/include/duckdb/parser/expression/between_expression.hpp
+++ b/src/include/duckdb/parser/expression/between_expression.hpp
@@ -16,8 +16,10 @@ class BetweenExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::BETWEEN;
 
-public:
+private:
 	BetweenExpression();
+
+public:
 	DUCKDB_API BetweenExpression(unique_ptr<ParsedExpression> input, unique_ptr<ParsedExpression> lower,
 	                             unique_ptr<ParsedExpression> upper);
 

--- a/src/include/duckdb/parser/expression/cast_expression.hpp
+++ b/src/include/duckdb/parser/expression/cast_expression.hpp
@@ -18,8 +18,10 @@ class CastExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::CAST;
 
-public:
+private:
 	CastExpression();
+
+public:
 	DUCKDB_API CastExpression(LogicalType target, unique_ptr<ParsedExpression> child, bool try_cast = false);
 
 	//! The child of the cast expression

--- a/src/include/duckdb/parser/expression/collate_expression.hpp
+++ b/src/include/duckdb/parser/expression/collate_expression.hpp
@@ -17,8 +17,10 @@ class CollateExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::COLLATE;
 
-public:
+private:
 	CollateExpression();
+
+public:
 	CollateExpression(string collation, unique_ptr<ParsedExpression> child);
 
 	//! The child of the cast expression

--- a/src/include/duckdb/parser/expression/columnref_expression.hpp
+++ b/src/include/duckdb/parser/expression/columnref_expression.hpp
@@ -19,8 +19,10 @@ class ColumnRefExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::COLUMN_REF;
 
-public:
+private:
 	ColumnRefExpression();
+
+public:
 	//! Specify both the column and table name
 	ColumnRefExpression(string column_name, string table_name);
 	//! Only specify the column name, the table name will be derived later

--- a/src/include/duckdb/parser/expression/comparison_expression.hpp
+++ b/src/include/duckdb/parser/expression/comparison_expression.hpp
@@ -17,8 +17,10 @@ class ComparisonExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::COMPARISON;
 
-public:
+private:
 	explicit ComparisonExpression(ExpressionType type);
+
+public:
 	DUCKDB_API ComparisonExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
 	                                unique_ptr<ParsedExpression> right);
 

--- a/src/include/duckdb/parser/expression/constant_expression.hpp
+++ b/src/include/duckdb/parser/expression/constant_expression.hpp
@@ -18,8 +18,10 @@ class ConstantExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::CONSTANT;
 
+private:
+	ConstantExpression();
+
 public:
-	DUCKDB_API ConstantExpression();
 	DUCKDB_API explicit ConstantExpression(Value val);
 
 	//! The constant value referenced

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -18,8 +18,10 @@ class FunctionExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::FUNCTION;
 
-public:
+private:
 	FunctionExpression();
+
+public:
 	DUCKDB_API FunctionExpression(string catalog_name, string schema_name, const string &function_name,
 	                              vector<unique_ptr<ParsedExpression>> children,
 	                              unique_ptr<ParsedExpression> filter = nullptr,

--- a/src/include/duckdb/parser/expression/lambda_expression.hpp
+++ b/src/include/duckdb/parser/expression/lambda_expression.hpp
@@ -21,8 +21,10 @@ class LambdaExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::LAMBDA;
 
-public:
+private:
 	LambdaExpression();
+
+public:
 	LambdaExpression(unique_ptr<ParsedExpression> lhs, unique_ptr<ParsedExpression> expr);
 
 	// we need the context to determine if this is a list of column references or an expression (for JSON)

--- a/src/include/duckdb/parser/expression/positional_reference_expression.hpp
+++ b/src/include/duckdb/parser/expression/positional_reference_expression.hpp
@@ -15,8 +15,10 @@ class PositionalReferenceExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::POSITIONAL_REFERENCE;
 
-public:
+private:
 	PositionalReferenceExpression();
+
+public:
 	DUCKDB_API PositionalReferenceExpression(idx_t index);
 
 	idx_t index;

--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -33,8 +33,10 @@ class WindowExpression : public ParsedExpression {
 public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::WINDOW;
 
-public:
+private:
 	explicit WindowExpression(ExpressionType type);
+
+public:
 	WindowExpression(ExpressionType type, string catalog_name, string schema_name, const string &function_name);
 
 	//! Catalog of the aggregate function

--- a/src/include/duckdb/parser/tableref/subqueryref.hpp
+++ b/src/include/duckdb/parser/tableref/subqueryref.hpp
@@ -17,8 +17,10 @@ class SubqueryRef : public TableRef {
 public:
 	static constexpr const TableReferenceType TYPE = TableReferenceType::SUBQUERY;
 
-public:
+private:
 	SubqueryRef();
+
+public:
 	DUCKDB_API explicit SubqueryRef(unique_ptr<SelectStatement> subquery, string alias = string());
 
 	//! The subquery

--- a/src/storage/serialization/serialize_parsed_expression.cpp
+++ b/src/storage/serialization/serialize_parsed_expression.cpp
@@ -84,7 +84,7 @@ void BetweenExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> BetweenExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<BetweenExpression>();
+	auto result = duckdb::unique_ptr<BetweenExpression>(new BetweenExpression());
 	deserializer.ReadProperty("input", result->input);
 	deserializer.ReadProperty("lower", result->lower);
 	deserializer.ReadProperty("upper", result->upper);
@@ -98,7 +98,7 @@ void CaseExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> CaseExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<CaseExpression>();
+	auto result = duckdb::unique_ptr<CaseExpression>(new CaseExpression());
 	deserializer.ReadProperty("case_checks", result->case_checks);
 	deserializer.ReadProperty("else_expr", result->else_expr);
 	return std::move(result);
@@ -112,7 +112,7 @@ void CastExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> CastExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<CastExpression>();
+	auto result = duckdb::unique_ptr<CastExpression>(new CastExpression());
 	deserializer.ReadProperty("child", result->child);
 	deserializer.ReadProperty("cast_type", result->cast_type);
 	deserializer.ReadProperty("try_cast", result->try_cast);
@@ -126,7 +126,7 @@ void CollateExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> CollateExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<CollateExpression>();
+	auto result = duckdb::unique_ptr<CollateExpression>(new CollateExpression());
 	deserializer.ReadProperty("child", result->child);
 	deserializer.ReadProperty("collation", result->collation);
 	return std::move(result);
@@ -138,7 +138,7 @@ void ColumnRefExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> ColumnRefExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<ColumnRefExpression>();
+	auto result = duckdb::unique_ptr<ColumnRefExpression>(new ColumnRefExpression());
 	deserializer.ReadProperty("column_names", result->column_names);
 	return std::move(result);
 }
@@ -150,7 +150,7 @@ void ComparisonExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> ComparisonExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<ComparisonExpression>(type);
+	auto result = duckdb::unique_ptr<ComparisonExpression>(new ComparisonExpression(type));
 	deserializer.ReadProperty("left", result->left);
 	deserializer.ReadProperty("right", result->right);
 	return std::move(result);
@@ -162,7 +162,7 @@ void ConjunctionExpression::FormatSerialize(FormatSerializer &serializer) const 
 }
 
 unique_ptr<ParsedExpression> ConjunctionExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<ConjunctionExpression>(type);
+	auto result = duckdb::unique_ptr<ConjunctionExpression>(new ConjunctionExpression(type));
 	deserializer.ReadProperty("children", result->children);
 	return std::move(result);
 }
@@ -173,7 +173,7 @@ void ConstantExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> ConstantExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<ConstantExpression>();
+	auto result = duckdb::unique_ptr<ConstantExpression>(new ConstantExpression());
 	deserializer.ReadProperty("value", result->value);
 	return std::move(result);
 }
@@ -183,7 +183,7 @@ void DefaultExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> DefaultExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<DefaultExpression>();
+	auto result = duckdb::unique_ptr<DefaultExpression>(new DefaultExpression());
 	return std::move(result);
 }
 
@@ -201,7 +201,7 @@ void FunctionExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> FunctionExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<FunctionExpression>();
+	auto result = duckdb::unique_ptr<FunctionExpression>(new FunctionExpression());
 	deserializer.ReadProperty("function_name", result->function_name);
 	deserializer.ReadProperty("schema", result->schema);
 	deserializer.ReadProperty("children", result->children);
@@ -222,7 +222,7 @@ void LambdaExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> LambdaExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<LambdaExpression>();
+	auto result = duckdb::unique_ptr<LambdaExpression>(new LambdaExpression());
 	deserializer.ReadProperty("lhs", result->lhs);
 	deserializer.ReadProperty("expr", result->expr);
 	return std::move(result);
@@ -234,7 +234,7 @@ void OperatorExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> OperatorExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<OperatorExpression>(type);
+	auto result = duckdb::unique_ptr<OperatorExpression>(new OperatorExpression(type));
 	deserializer.ReadProperty("children", result->children);
 	return std::move(result);
 }
@@ -245,7 +245,7 @@ void ParameterExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> ParameterExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<ParameterExpression>();
+	auto result = duckdb::unique_ptr<ParameterExpression>(new ParameterExpression());
 	deserializer.ReadProperty("parameter_nr", result->parameter_nr);
 	return std::move(result);
 }
@@ -256,7 +256,7 @@ void PositionalReferenceExpression::FormatSerialize(FormatSerializer &serializer
 }
 
 unique_ptr<ParsedExpression> PositionalReferenceExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<PositionalReferenceExpression>();
+	auto result = duckdb::unique_ptr<PositionalReferenceExpression>(new PositionalReferenceExpression());
 	deserializer.ReadProperty("index", result->index);
 	return std::move(result);
 }
@@ -271,7 +271,7 @@ void StarExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> StarExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<StarExpression>();
+	auto result = duckdb::unique_ptr<StarExpression>(new StarExpression());
 	deserializer.ReadProperty("relation_name", result->relation_name);
 	deserializer.ReadProperty("exclude_list", result->exclude_list);
 	deserializer.ReadProperty("replace_list", result->replace_list);
@@ -289,7 +289,7 @@ void SubqueryExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> SubqueryExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<SubqueryExpression>();
+	auto result = duckdb::unique_ptr<SubqueryExpression>(new SubqueryExpression());
 	deserializer.ReadProperty("subquery_type", result->subquery_type);
 	deserializer.ReadProperty("subquery", result->subquery);
 	deserializer.ReadOptionalProperty("child", result->child);
@@ -316,7 +316,7 @@ void WindowExpression::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ParsedExpression> WindowExpression::FormatDeserialize(ExpressionType type, FormatDeserializer &deserializer) {
-	auto result = make_uniq<WindowExpression>(type);
+	auto result = duckdb::unique_ptr<WindowExpression>(new WindowExpression(type));
 	deserializer.ReadProperty("function_name", result->function_name);
 	deserializer.ReadProperty("schema", result->schema);
 	deserializer.ReadProperty("catalog", result->catalog);

--- a/src/storage/serialization/serialize_query_node.cpp
+++ b/src/storage/serialization/serialize_query_node.cpp
@@ -52,7 +52,7 @@ void SelectNode::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<QueryNode> SelectNode::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<SelectNode>();
+	auto result = duckdb::unique_ptr<SelectNode>(new SelectNode());
 	deserializer.ReadProperty("select_list", result->select_list);
 	deserializer.ReadOptionalProperty("from_table", result->from_table);
 	deserializer.ReadOptionalProperty("where_clause", result->where_clause);
@@ -73,7 +73,7 @@ void SetOperationNode::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<QueryNode> SetOperationNode::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<SetOperationNode>();
+	auto result = duckdb::unique_ptr<SetOperationNode>(new SetOperationNode());
 	deserializer.ReadProperty("setop_type", result->setop_type);
 	deserializer.ReadProperty("left", result->left);
 	deserializer.ReadProperty("right", result->right);
@@ -90,7 +90,7 @@ void RecursiveCTENode::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<QueryNode> RecursiveCTENode::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<RecursiveCTENode>();
+	auto result = duckdb::unique_ptr<RecursiveCTENode>(new RecursiveCTENode());
 	deserializer.ReadProperty("cte_name", result->ctename);
 	deserializer.ReadProperty("union_all", result->union_all);
 	deserializer.ReadProperty("left", result->left);
@@ -108,7 +108,7 @@ void CTENode::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<QueryNode> CTENode::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<CTENode>();
+	auto result = duckdb::unique_ptr<CTENode>(new CTENode());
 	deserializer.ReadProperty("cte_name", result->ctename);
 	deserializer.ReadProperty("query", result->query);
 	deserializer.ReadProperty("child", result->child);

--- a/src/storage/serialization/serialize_result_modifier.cpp
+++ b/src/storage/serialization/serialize_result_modifier.cpp
@@ -39,7 +39,7 @@ void LimitModifier::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ResultModifier> LimitModifier::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<LimitModifier>();
+	auto result = duckdb::unique_ptr<LimitModifier>(new LimitModifier());
 	deserializer.ReadOptionalProperty("limit", result->limit);
 	deserializer.ReadOptionalProperty("offset", result->offset);
 	return std::move(result);
@@ -51,7 +51,7 @@ void DistinctModifier::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ResultModifier> DistinctModifier::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<DistinctModifier>();
+	auto result = duckdb::unique_ptr<DistinctModifier>(new DistinctModifier());
 	deserializer.ReadProperty("distinct_on_targets", result->distinct_on_targets);
 	return std::move(result);
 }
@@ -62,7 +62,7 @@ void OrderModifier::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ResultModifier> OrderModifier::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<OrderModifier>();
+	auto result = duckdb::unique_ptr<OrderModifier>(new OrderModifier());
 	deserializer.ReadProperty("orders", result->orders);
 	return std::move(result);
 }
@@ -74,7 +74,7 @@ void LimitPercentModifier::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<ResultModifier> LimitPercentModifier::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<LimitPercentModifier>();
+	auto result = duckdb::unique_ptr<LimitPercentModifier>(new LimitPercentModifier());
 	deserializer.ReadOptionalProperty("limit", result->limit);
 	deserializer.ReadOptionalProperty("offset", result->offset);
 	return std::move(result);

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -56,7 +56,7 @@ void BaseTableRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> BaseTableRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<BaseTableRef>();
+	auto result = duckdb::unique_ptr<BaseTableRef>(new BaseTableRef());
 	deserializer.ReadProperty("schema_name", result->schema_name);
 	deserializer.ReadProperty("table_name", result->table_name);
 	deserializer.ReadProperty("column_name_alias", result->column_name_alias);
@@ -75,7 +75,7 @@ void JoinRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> JoinRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<JoinRef>();
+	auto result = duckdb::unique_ptr<JoinRef>(new JoinRef());
 	deserializer.ReadProperty("left", result->left);
 	deserializer.ReadProperty("right", result->right);
 	deserializer.ReadOptionalProperty("condition", result->condition);
@@ -92,7 +92,7 @@ void SubqueryRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> SubqueryRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<SubqueryRef>();
+	auto result = duckdb::unique_ptr<SubqueryRef>(new SubqueryRef());
 	deserializer.ReadProperty("subquery", result->subquery);
 	deserializer.ReadProperty("column_name_alias", result->column_name_alias);
 	return std::move(result);
@@ -106,7 +106,7 @@ void TableFunctionRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> TableFunctionRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<TableFunctionRef>();
+	auto result = duckdb::unique_ptr<TableFunctionRef>(new TableFunctionRef());
 	deserializer.ReadProperty("function", result->function);
 	deserializer.ReadProperty("alias", result->alias);
 	deserializer.ReadProperty("column_name_alias", result->column_name_alias);
@@ -118,7 +118,7 @@ void EmptyTableRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> EmptyTableRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<EmptyTableRef>();
+	auto result = duckdb::unique_ptr<EmptyTableRef>(new EmptyTableRef());
 	return std::move(result);
 }
 
@@ -130,7 +130,7 @@ void ExpressionListRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> ExpressionListRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<ExpressionListRef>();
+	auto result = duckdb::unique_ptr<ExpressionListRef>(new ExpressionListRef());
 	deserializer.ReadProperty("expected_names", result->expected_names);
 	deserializer.ReadProperty("expected_types", result->expected_types);
 	deserializer.ReadProperty("values", result->values);
@@ -149,7 +149,7 @@ void PivotRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> PivotRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto result = make_uniq<PivotRef>();
+	auto result = duckdb::unique_ptr<PivotRef>(new PivotRef());
 	deserializer.ReadProperty("source", result->source);
 	deserializer.ReadProperty("aggregates", result->aggregates);
 	deserializer.ReadProperty("unpivot_names", result->unpivot_names);


### PR DESCRIPTION
Hi!

My main comment on https://github.com/duckdb/duckdb/pull/8156 was better expressed as code plus I wanted to give it a try, so here a PR on a PR.

Basically I feel a bit uneasy about exposing the default constructors publicly, since I fear it will lead to stuff like `vector<SomeClass> v(100);` being used, leading to potentially hard to spot bugs around logically not fully initialised instances + adds complexity when reasoning around the class.

I think one problem that led to going with `public` was that make_uniq that would need to be a member (defeating the purpose), so I guessed that skipping make_uniq and substituting with its implementation should do the trick.