### PR TITLE
Partitioned write - flush batches periodically (every 500K rows) instead of only writing when all data has been gathered

### DIFF
--- a/benchmark/micro/copy/to_parquet_partition_by_few.benchmark
+++ b/benchmark/micro/copy/to_parquet_partition_by_few.benchmark
@@ -5,5 +5,8 @@
 name Copy to Parquet, 2 partitions
 group copy
 
+load
+CREATE TABLE tbl AS SELECT i%2::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i)
+
 run
-COPY (SELECT i%2::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i)) TO '${BENCHMARK_DIR}/partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);
+COPY tbl TO '${BENCHMARK_DIR}/partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);

--- a/benchmark/micro/copy/to_parquet_partition_by_many.benchmark
+++ b/benchmark/micro/copy/to_parquet_partition_by_many.benchmark
@@ -5,5 +5,8 @@
 name Copy to Parquet, 1000 partitions
 group copy
 
+load
+CREATE TABLE tbl AS SELECT i%1000::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i);
+
 run
-COPY (SELECT i%1000::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i)) TO '${BENCHMARK_DIR}/partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);
+COPY tbl TO  'partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);

--- a/benchmark/micro/copy/to_parquet_partition_by_many.benchmark
+++ b/benchmark/micro/copy/to_parquet_partition_by_many.benchmark
@@ -9,4 +9,4 @@ load
 CREATE TABLE tbl AS SELECT i%1000::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i);
 
 run
-COPY tbl TO  'partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);
+COPY tbl TO  '${BENCHMARK_DIR}/partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -150,6 +150,7 @@ protected:
 	//! Synchronization for upload threads
 	mutex uploads_in_progress_lock;
 	std::condition_variable uploads_in_progress_cv;
+	std::condition_variable final_flush_cv;
 	uint16_t uploads_in_progress;
 
 	//! Etags are stored for each part
@@ -233,6 +234,7 @@ public:
 	}
 
 protected:
+	static void NotifyUploadsInProgress(S3FileHandle &file_handle);
 	duckdb::unique_ptr<HTTPFileHandle> CreateHandle(const string &path, uint8_t flags, FileLockType lock,
 	                                                FileCompressionType compression, FileOpener *opener) override;
 

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -179,12 +179,6 @@ public:
 	explicit S3FileSystem(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
 	}
 
-	// Global limits to write buffers
-	mutex buffers_available_lock;
-	std::condition_variable buffers_available_cv;
-	uint16_t buffers_in_use = 0;
-	uint16_t threads_waiting_for_memory = 0;
-
 	BufferManager &buffer_manager;
 	string GetName() const override;
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -390,6 +390,17 @@ string S3FileSystem::InitializeMultipartUpload(S3FileHandle &file_handle) {
 	return result.substr(open_tag_pos, close_tag_pos - open_tag_pos);
 }
 
+void S3FileSystem::NotifyUploadsInProgress(S3FileHandle &file_handle) {
+	{
+		unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
+		file_handle.uploads_in_progress--;
+	}
+	// Note that there are 2 cv's because otherwise we might deadlock when the final flushing thread is notified while
+	// another thread is still waiting for an upload thread
+	file_handle.uploads_in_progress_cv.notify_one();
+	file_handle.final_flush_cv.notify_one();
+}
+
 void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
 
@@ -420,11 +431,7 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 			file_handle.upload_exception = std::current_exception();
 		}
 
-		{
-			unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
-			file_handle.uploads_in_progress--;
-		}
-		file_handle.uploads_in_progress_cv.notify_one();
+		NotifyUploadsInProgress(file_handle);
 
 		return;
 	}
@@ -440,12 +447,7 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 	// Free up space for another thread to acquire an S3WriteBuffer
 	write_buffer.reset();
 
-	// Signal a thread has finished
-	{
-		unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
-		file_handle.uploads_in_progress--;
-	}
-	file_handle.uploads_in_progress_cv.notify_one();
+	NotifyUploadsInProgress(file_handle);
 }
 
 void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
@@ -504,7 +506,7 @@ void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
 		}
 	}
 	unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
-	file_handle.uploads_in_progress_cv.wait(lck, [&file_handle] { return file_handle.uploads_in_progress == 0; });
+	file_handle.final_flush_cv.wait(lck, [&file_handle] { return file_handle.uploads_in_progress == 0; });
 
 	file_handle.RethrowIOError();
 }

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -474,7 +474,9 @@ void S3FileSystem::FlushBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuff
 		// check if there are upload threads available
 		if (file_handle.uploads_in_progress >= file_handle.config_params.max_upload_threads) {
 			// there are not - wait for one to become available
-			file_handle.uploads_in_progress_cv.wait(lck, [&file_handle] { return file_handle.uploads_in_progress < file_handle.config_params.max_upload_threads; });
+			file_handle.uploads_in_progress_cv.wait(lck, [&file_handle] {
+				return file_handle.uploads_in_progress < file_handle.config_params.max_upload_threads;
+			});
 		}
 		file_handle.uploads_in_progress++;
 	}

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -440,13 +440,6 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 	// Free up space for another thread to acquire an S3WriteBuffer
 	write_buffer.reset();
 
-	// Signal a buffer has become available
-	{
-		unique_lock<mutex> lck(s3fs.buffers_available_lock);
-		s3fs.buffers_in_use--;
-	}
-	s3fs.buffers_available_cv.notify_one();
-
 	// Signal a thread has finished
 	{
 		unique_lock<mutex> lck(file_handle.uploads_in_progress_lock);
@@ -546,44 +539,7 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 
 // Wrapper around the BufferManager::Allocate to that allows limiting the number of buffers that will be handed out
 BufferHandle S3FileSystem::Allocate(idx_t part_size, uint16_t max_threads) {
-	unique_lock<mutex> lck(buffers_available_lock);
-
-	// Wait for a buffer to become available
-	if (buffers_in_use + threads_waiting_for_memory >= max_threads) {
-		buffers_available_cv.wait(lck, [&] { return buffers_in_use + threads_waiting_for_memory < max_threads; });
-	}
-	buffers_in_use++;
-
-	// Try to allocate a buffer from the buffer manager
-	BufferHandle duckdb_buffer;
-	bool set_waiting_for_memory = false;
-
-	while (true) {
-		try {
-			duckdb_buffer = buffer_manager.Allocate(MemoryTag::EXTENSION, part_size);
-
-			if (set_waiting_for_memory) {
-				threads_waiting_for_memory--;
-			}
-			break;
-		} catch (OutOfMemoryException &e) {
-			if (!set_waiting_for_memory) {
-				threads_waiting_for_memory++;
-				set_waiting_for_memory = true;
-			}
-
-			auto currently_in_use = buffers_in_use;
-			if (currently_in_use == 0) {
-				// There exist no upload write buffers that can release more memory. We really ran out of memory here.
-				throw;
-			} else {
-				// Wait for more buffers to become available before trying again
-				buffers_available_cv.wait(lck, [&] { return buffers_in_use < currently_in_use; });
-			}
-		}
-	}
-
-	return duckdb_buffer;
+	return buffer_manager.Allocate(MemoryTag::EXTENSION, part_size);
 }
 
 shared_ptr<S3WriteBuffer> S3FileHandle::GetBuffer(uint16_t write_buffer_idx) {

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -100,7 +100,7 @@ def parse_assertions(stdout):
 
 for test_number, test_case in enumerate(test_cases):
     if not profile:
-        print(f"[{test_number}/{test_count}]: {test_case}", end="")
+        print(f"[{test_number}/{test_count}]: {test_case}", end="", flush=True)
     start = time.time()
     try:
         res = subprocess.run(

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -7,7 +7,7 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/storage/storage_lock.hpp"
-
+#include "duckdb/common/value_operations/value_operations.hpp"
 #include <algorithm>
 
 namespace duckdb {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -25,10 +25,83 @@ public:
 
 	//! shared state for HivePartitionedColumnData
 	shared_ptr<GlobalHivePartitionState> partition_state;
+
+	static void CreateDir(const string &dir_path, FileSystem &fs) {
+		if (!fs.DirectoryExists(dir_path)) {
+			fs.CreateDirectory(dir_path);
+		}
+	}
+
+	static void CreateDirectories(const vector<idx_t> &cols, const vector<string> &names, const vector<Value> &values,
+	                              string path, FileSystem &fs) {
+		CreateDir(path, fs);
+
+		for (idx_t i = 0; i < cols.size(); i++) {
+			const auto &partition_col_name = names[cols[i]];
+			const auto &partition_value = values[i];
+			string p_dir = partition_col_name + "=" + partition_value.ToString();
+			path = fs.JoinPath(path, p_dir);
+			CreateDir(path, fs);
+		}
+	}
+
+	void CreatePartitionDirectories(ClientContext &context, const PhysicalCopyToFile &op) {
+		auto &fs = FileSystem::GetFileSystem(context);
+
+		auto trimmed_path = op.GetTrimmedPath(context);
+
+		auto l = lock.GetExclusiveLock();
+		lock_guard<mutex> global_lock_on_partition_state(partition_state->lock);
+		const auto &global_partitions = partition_state->partitions;
+		// global_partitions have partitions added only at the back, so it's fine to only traverse the last part
+
+		for (idx_t i = created_directories; i < global_partitions.size(); i++) {
+			CreateDirectories(op.partition_columns, op.names, global_partitions[i]->first.values, trimmed_path, fs);
+		}
+		created_directories = global_partitions.size();
+	}
+};
+
+string PhysicalCopyToFile::GetTrimmedPath(ClientContext &context) const {
+	auto &fs = FileSystem::GetFileSystem(context);
+	string trimmed_path = file_path;
+	StringUtil::RTrim(trimmed_path, fs.PathSeparator(trimmed_path));
+	return trimmed_path;
+}
+
+struct PartitionWriteInfo {
+	unique_ptr<LocalFunctionData> local_state;
+	unique_ptr<GlobalFunctionData> global_state;
+};
+
+struct VectorOfValuesHashFunction {
+	uint64_t operator()(const vector<Value> &values) const {
+		hash_t result = 0;
+		for (auto &val : values) {
+			result ^= val.Hash();
+		}
+		return result;
+	}
+};
+
+struct VectorOfValuesEquality {
+	bool operator()(const vector<Value> &a, const vector<Value> &b) const {
+		if (a.size() != b.size()) {
+			return false;
+		}
+		for (idx_t i = 0; i < a.size(); i++) {
+			if (ValueOperations::DistinctFrom(a[i], b[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
 };
 
 class CopyToFunctionLocalState : public LocalSinkState {
 public:
+	static constexpr const idx_t PARTITIONED_FLUSH_THRESHOLD = 500000;
+
 	explicit CopyToFunctionLocalState(unique_ptr<LocalFunctionData> local_state)
 	    : local_state(std::move(local_state)), writer_offset(0) {
 	}
@@ -39,7 +112,123 @@ public:
 	unique_ptr<HivePartitionedColumnData> part_buffer;
 	unique_ptr<PartitionedColumnDataAppendState> part_buffer_append_state;
 
+	unordered_map<vector<Value>, unique_ptr<PartitionWriteInfo>, VectorOfValuesHashFunction, VectorOfValuesEquality>
+	    active_write_map;
+
 	idx_t writer_offset;
+	idx_t append_count = 0;
+
+	void InitializeAppendState(ClientContext &context, const PhysicalCopyToFile &op,
+	                           CopyToFunctionGlobalState &gstate) {
+		part_buffer = make_uniq<HivePartitionedColumnData>(context, op.expected_types, op.partition_columns,
+		                                                   gstate.partition_state);
+		part_buffer_append_state = make_uniq<PartitionedColumnDataAppendState>();
+		part_buffer->InitializeAppendState(*part_buffer_append_state);
+		append_count = 0;
+	}
+
+	void AppendToPartition(ExecutionContext &context, const PhysicalCopyToFile &op, CopyToFunctionGlobalState &g,
+	                       DataChunk &chunk) {
+		if (!part_buffer) {
+			// re-initialize the append
+			InitializeAppendState(context.client, op, g);
+		}
+		part_buffer->Append(*part_buffer_append_state, chunk);
+		append_count += chunk.size();
+		if (append_count >= PARTITIONED_FLUSH_THRESHOLD) {
+			// flush all cached partitions
+			FlushPartitions(context, op, g, false);
+		}
+	}
+
+	static string GetDirectory(const vector<idx_t> &cols, const vector<string> &names, const vector<Value> &values,
+	                           string path, FileSystem &fs) {
+		for (idx_t i = 0; i < cols.size(); i++) {
+			const auto &partition_col_name = names[cols[i]];
+			const auto &partition_value = values[i];
+			string p_dir = partition_col_name + "=" + partition_value.ToString();
+			path = fs.JoinPath(path, p_dir);
+		}
+		return path;
+	}
+
+	PartitionWriteInfo &GetPartitionWriteInfo(ExecutionContext &context, const PhysicalCopyToFile &op,
+	                                          const vector<Value> &values) {
+		// check if we have already started writing this partition
+		auto entry = active_write_map.find(values);
+		if (entry != active_write_map.end()) {
+			// we have - continue writing in this partition
+			return *entry->second;
+		}
+		auto &fs = FileSystem::GetFileSystem(context.client);
+		// Create a writer for the current file
+		auto trimmed_path = op.GetTrimmedPath(context.client);
+		string hive_path = GetDirectory(op.partition_columns, op.names, values, trimmed_path, fs);
+		string full_path(op.filename_pattern.CreateFilename(fs, hive_path, op.file_extension, writer_offset));
+		if (fs.FileExists(full_path) && !op.overwrite_or_ignore) {
+			throw IOException("failed to create %s, file exists! Enable OVERWRITE_OR_IGNORE option to force writing",
+			                  full_path);
+		}
+		// initialize writes
+		auto info = make_uniq<PartitionWriteInfo>();
+		info->global_state = op.function.copy_to_initialize_global(context.client, *op.bind_data, full_path);
+		info->local_state = op.function.copy_to_initialize_local(context, *op.bind_data);
+		auto &result = *info;
+		// store in active write map
+		active_write_map.insert(make_pair(values, std::move(info)));
+		return result;
+	}
+
+	void FinalizePartition(ExecutionContext &context, const PhysicalCopyToFile &op, PartitionWriteInfo &info) {
+		if (!info.global_state) {
+			// already finalized
+			return;
+		}
+		// finalize the partition
+		op.function.copy_to_combine(context, *op.bind_data, *info.global_state, *info.local_state);
+		op.function.copy_to_finalize(context.client, *op.bind_data, *info.global_state);
+		info.global_state.reset();
+		info.local_state.reset();
+	}
+
+	void ResetAppendState() {
+		part_buffer_append_state.reset();
+		part_buffer.reset();
+		append_count = 0;
+	}
+
+	void FlushPartitions(ExecutionContext &context, const PhysicalCopyToFile &op, CopyToFunctionGlobalState &g,
+	                     bool final_flush) {
+		part_buffer->FlushAppendState(*part_buffer_append_state);
+		auto &partitions = part_buffer->GetPartitions();
+		auto partition_key_map = part_buffer->GetReverseMap();
+
+		// ensure all partition directories are created before we start writing
+		g.CreatePartitionDirectories(context.client, op);
+
+		for (idx_t i = 0; i < partitions.size(); i++) {
+			// get the partition write info for this buffer
+			auto &info = GetPartitionWriteInfo(context, op, partition_key_map[i]->values);
+
+			// push the chunks into the write state
+			for (auto &chunk : partitions[i]->Chunks()) {
+				op.function.copy_to_sink(context, *op.bind_data, *info.global_state, *info.local_state, chunk);
+			}
+			if (final_flush) {
+				// if this is the final flush already finalize the write
+				FinalizePartition(context, op, info);
+			}
+			partitions[i].reset();
+		}
+		ResetAppendState();
+	}
+
+	void FinalizePartitions(ExecutionContext &context, const PhysicalCopyToFile &op) {
+		// finalize any remaining partitions
+		for (auto &entry : active_write_map) {
+			FinalizePartition(context, op, *entry.second);
+		}
+	}
 };
 
 unique_ptr<GlobalFunctionData> PhysicalCopyToFile::CreateFileState(ClientContext &context,
@@ -60,10 +249,7 @@ unique_ptr<LocalSinkState> PhysicalCopyToFile::GetLocalSinkState(ExecutionContex
 
 		auto state = make_uniq<CopyToFunctionLocalState>(nullptr);
 		state->writer_offset = g.last_file_offset++;
-		state->part_buffer =
-		    make_uniq<HivePartitionedColumnData>(context.client, expected_types, partition_columns, g.partition_state);
-		state->part_buffer_append_state = make_uniq<PartitionedColumnDataAppendState>();
-		state->part_buffer->InitializeAppendState(*state->part_buffer_append_state);
+		state->InitializeAppendState(context.client, *this, g);
 		return std::move(state);
 	}
 	auto res = make_uniq<CopyToFunctionLocalState>(function.copy_to_initialize_local(context, *bind_data));
@@ -139,7 +325,7 @@ SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, DataChunk &ch
 	auto &l = input.local_state.Cast<CopyToFunctionLocalState>();
 
 	if (partition_output) {
-		l.part_buffer->Append(*l.part_buffer_append_state, chunk);
+		l.AppendToPartition(context, *this, g, chunk);
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
@@ -179,79 +365,15 @@ SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, DataChunk &ch
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
-static void CreateDir(const string &dir_path, FileSystem &fs) {
-	if (!fs.DirectoryExists(dir_path)) {
-		fs.CreateDirectory(dir_path);
-	}
-}
-
-static void CreateDirectories(const vector<idx_t> &cols, const vector<string> &names, const vector<Value> &values,
-                              string path, FileSystem &fs) {
-	CreateDir(path, fs);
-
-	for (idx_t i = 0; i < cols.size(); i++) {
-		const auto &partition_col_name = names[cols[i]];
-		const auto &partition_value = values[i];
-		string p_dir = partition_col_name + "=" + partition_value.ToString();
-		path = fs.JoinPath(path, p_dir);
-		CreateDir(path, fs);
-	}
-}
-
-static string GetDirectory(const vector<idx_t> &cols, const vector<string> &names, const vector<Value> &values,
-                           string path, FileSystem &fs) {
-	for (idx_t i = 0; i < cols.size(); i++) {
-		const auto &partition_col_name = names[cols[i]];
-		const auto &partition_value = values[i];
-		string p_dir = partition_col_name + "=" + partition_value.ToString();
-		path = fs.JoinPath(path, p_dir);
-	}
-	return path;
-}
-
 SinkCombineResultType PhysicalCopyToFile::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
 	auto &g = input.global_state.Cast<CopyToFunctionGlobalState>();
 	auto &l = input.local_state.Cast<CopyToFunctionLocalState>();
 
 	if (partition_output) {
-		auto &fs = FileSystem::GetFileSystem(context.client);
-		l.part_buffer->FlushAppendState(*l.part_buffer_append_state);
-		auto &partitions = l.part_buffer->GetPartitions();
-		auto partition_key_map = l.part_buffer->GetReverseMap();
-
-		string trimmed_path = file_path;
-		StringUtil::RTrim(trimmed_path, fs.PathSeparator(trimmed_path));
-		{
-			// create directories
-			auto lock = g.lock.GetExclusiveLock();
-			lock_guard<mutex> global_lock_on_partition_state(g.partition_state->lock);
-			const auto &global_partitions = g.partition_state->partitions;
-			// global_partitions have partitions added only at the back, so it's fine to only traverse the last part
-
-			for (idx_t i = g.created_directories; i < global_partitions.size(); i++) {
-				CreateDirectories(partition_columns, names, global_partitions[i]->first.values, trimmed_path, fs);
-			}
-			g.created_directories = global_partitions.size();
-		}
-
-		for (idx_t i = 0; i < partitions.size(); i++) {
-			string hive_path = GetDirectory(partition_columns, names, partition_key_map[i]->values, trimmed_path, fs);
-			string full_path(filename_pattern.CreateFilename(fs, hive_path, file_extension, l.writer_offset));
-			if (fs.FileExists(full_path) && !overwrite_or_ignore) {
-				throw IOException(
-				    "failed to create %s, file exists! Enable OVERWRITE_OR_IGNORE option to force writing", full_path);
-			}
-			// Create a writer for the current file
-			auto fun_data_global = function.copy_to_initialize_global(context.client, *bind_data, full_path);
-			auto fun_data_local = function.copy_to_initialize_local(context, *bind_data);
-
-			for (auto &chunk : partitions[i]->Chunks()) {
-				function.copy_to_sink(context, *bind_data, *fun_data_global, *fun_data_local, chunk);
-			}
-
-			function.copy_to_combine(context, *bind_data, *fun_data_global, *fun_data_local);
-			function.copy_to_finalize(context.client, *bind_data, *fun_data_global);
-		}
+		// flush all remaining partitions
+		l.FlushPartitions(context, *this, g, true);
+		// finalize any outstanding partitions
+		l.FinalizePartitions(context, *this);
 	} else if (function.copy_to_combine) {
 		if (per_thread_output) {
 			// For PER_THREAD_OUTPUT, we can combine/finalize immediately

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -93,7 +93,7 @@ public:
 	}
 
 	static string GetDirectory(const vector<idx_t> &cols, const vector<string> &names, const vector<Value> &values,
-							   string path, FileSystem &fs) {
+	                           string path, FileSystem &fs) {
 		for (idx_t i = 0; i < cols.size(); i++) {
 			const auto &partition_col_name = names[cols[i]];
 			const auto &partition_value = values[i];
@@ -121,7 +121,7 @@ public:
 	}
 
 	PartitionWriteInfo &GetPartitionWriteInfo(ExecutionContext &context, const PhysicalCopyToFile &op,
-											  const vector<Value> &values) {
+	                                          const vector<Value> &values) {
 		auto l = lock.GetExclusiveLock();
 		// check if we have already started writing this partition
 		auto entry = active_partitioned_writes.find(values);
@@ -136,7 +136,7 @@ public:
 		string full_path(op.filename_pattern.CreateFilename(fs, hive_path, op.file_extension, 0));
 		if (fs.FileExists(full_path) && !op.overwrite_or_ignore) {
 			throw IOException("failed to create %s, file exists! Enable OVERWRITE_OR_IGNORE option to force writing",
-							  full_path);
+			                  full_path);
 		}
 		// initialize writes
 		auto info = make_uniq<PartitionWriteInfo>();

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -72,6 +72,8 @@ public:
 
 	static void MoveTmpFile(ClientContext &context, const string &tmp_file_path);
 
+	string GetTrimmedPath(ClientContext &context) const;
+
 private:
 	unique_ptr<GlobalFunctionData> CreateFileState(ClientContext &context, GlobalSinkState &sink) const;
 };

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -87,6 +87,8 @@ struct ClientConfig {
 	idx_t perfect_ht_threshold = 12;
 	//! The maximum number of rows to accumulate before sorting ordered aggregates.
 	idx_t ordered_aggregate_threshold = (idx_t(1) << 18);
+	//! The number of rows to accumulate before flushing during a partitioned write
+	idx_t partitioned_write_flush_threshold = idx_t(1) << idx_t(19);
 
 	//! Callback to create a progress bar display
 	progress_bar_display_create_func_t display_create_func = nullptr;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -305,6 +305,16 @@ struct ExplainOutputSetting {
 	static Value GetSetting(ClientContext &context);
 };
 
+struct ExportLargeBufferArrow {
+	static constexpr const char *Name = "arrow_large_buffer_size";
+	static constexpr const char *Description =
+	    "If arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(ClientContext &context);
+};
+
 struct ExtensionDirectorySetting {
 	static constexpr const char *Name = "extension_directory";
 	static constexpr const char *Description = "Set the directory to store extensions in";
@@ -427,6 +437,16 @@ struct OldImplicitCasting {
 	static Value GetSetting(ClientContext &context);
 };
 
+struct PartitionedWriteFlushThreshold {
+	static constexpr const char *Name = "partitioned_write_flush_threshold";
+	static constexpr const char *Description =
+	    "The threshold in number of rows after which we flush a thread state when writing using PARTITION_BY";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(ClientContext &context);
+};
+
 struct PasswordSetting {
 	static constexpr const char *Name = "password";
 	static constexpr const char *Description = "The password to use. Ignored for legacy compatibility.";
@@ -480,16 +500,6 @@ struct PreserveInsertionOrder {
 	static constexpr const char *Description =
 	    "Whether or not to preserve insertion order. If set to false the system is allowed to re-order any results "
 	    "that do not contain ORDER BY clauses.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
-	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
-};
-
-struct ExportLargeBufferArrow {
-	static constexpr const char *Name = "arrow_large_buffer_size";
-	static constexpr const char *Description =
-	    "If arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -121,6 +121,7 @@ static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting
                                                  DUCKDB_GLOBAL(FlushAllocatorSetting),
                                                  DUCKDB_GLOBAL(DuckDBApiSetting),
                                                  DUCKDB_GLOBAL(CustomUserAgentSetting),
+                                                 DUCKDB_LOCAL(PartitionedWriteFlushThreshold),
                                                  FINAL_SETTING};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -965,6 +965,22 @@ Value OldImplicitCasting::GetSetting(ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Partitioned Write Flush Threshold
+//===--------------------------------------------------------------------===//
+void PartitionedWriteFlushThreshold::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).partitioned_write_flush_threshold =
+	    ClientConfig().partitioned_write_flush_threshold;
+}
+
+void PartitionedWriteFlushThreshold::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).partitioned_write_flush_threshold = input.GetValue<idx_t>();
+}
+
+Value PartitionedWriteFlushThreshold::GetSetting(ClientContext &context) {
+	return Value::BIGINT(ClientConfig::GetConfig(context).partitioned_write_flush_threshold);
+}
+
+//===--------------------------------------------------------------------===//
 // Password Setting
 //===--------------------------------------------------------------------===//
 void PasswordSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -93,6 +93,7 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"perfect_ht_threshold", {0}},
 	    {"pivot_filter_threshold", {999}},
 	    {"pivot_limit", {999}},
+	    {"partitioned_write_flush_threshold", {123}},
 	    {"preserve_identifier_case", {false}},
 	    {"preserve_insertion_order", {false}},
 	    {"profile_output", {"test"}},

--- a/test/sql/attach/attach_httpfs.test
+++ b/test/sql/attach/attach_httpfs.test
@@ -33,7 +33,7 @@ NULL	NULL	NULL	NULL	NULL
 statement error
 CREATE TABLE db.integers(i INTEGER);
 ----
-Writing to HTTP files not implemented
+read-only
 
 statement ok
 SELECT * FROM db.all_types

--- a/test/sql/copy/partitioned/partitioned_write_tpch.test_slow
+++ b/test/sql/copy/partitioned/partitioned_write_tpch.test_slow
@@ -9,15 +9,52 @@ require tpch
 statement ok
 CALL dbgen(sf=1);
 
+# test writing with a very low partition threshold
+statement ok
+SET partitioned_write_flush_threshold=10000;
+
 # write lineitem partitioned by l_returnflag and l_linestatus
 statement ok
-COPY lineitem TO  '__TEST_DIR__/lineitem_partitioned' (FORMAT PARQUET, PARTITION_BY (l_returnflag, l_linestatus));
+COPY lineitem TO  '__TEST_DIR__/lineitem_partitioned_parquet' (FORMAT PARQUET, PARTITION_BY (l_returnflag, l_linestatus));
+
+# write to CSV as well
+statement ok
+COPY lineitem TO  '__TEST_DIR__/lineitem_partitioned_csv' (FORMAT CSV, PARTITION_BY (l_returnflag, l_linestatus));
 
 statement ok
 DROP TABLE lineitem
 
 statement ok
-CREATE VIEW lineitem AS FROM '__TEST_DIR__/lineitem_partitioned/**/*.parquet'
+CREATE VIEW lineitem AS FROM '__TEST_DIR__/lineitem_partitioned_parquet/**/*.parquet'
+
+# now run tpc-h - results should be the same
+loop i 1 9
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+
+endloop
+
+statement ok
+DROP VIEW lineitem
+
+# try the CSV next - but copy it into a regular table
+statement ok
+CREATE TABLE lineitem(l_orderkey INTEGER NOT NULL, l_partkey INTEGER NOT NULL, l_suppkey INTEGER NOT NULL, l_linenumber INTEGER NOT NULL, l_quantity DECIMAL(15,2) NOT NULL, l_extendedprice DECIMAL(15,2) NOT NULL, l_discount DECIMAL(15,2) NOT NULL, l_tax DECIMAL(15,2) NOT NULL, l_returnflag VARCHAR NOT NULL, l_linestatus VARCHAR NOT NULL, l_shipdate DATE NOT NULL, l_commitdate DATE NOT NULL, l_receiptdate DATE NOT NULL, l_shipinstruct VARCHAR NOT NULL, l_shipmode VARCHAR NOT NULL, l_comment VARCHAR NOT NULL);
+
+statement ok
+COPY lineitem FROM '__TEST_DIR__/lineitem_partitioned_csv/**/*.csv'
 
 # now run tpc-h - results should be the same
 loop i 1 9

--- a/test/sql/copy/partitioned/partitioned_write_tpch.test_slow
+++ b/test/sql/copy/partitioned/partitioned_write_tpch.test_slow
@@ -1,0 +1,39 @@
+# name: test/sql/copy/partitioned/partitioned_write_tpch.test_slow
+# description: TPC-H test for hive partitioned write
+# group: [partitioned]
+
+require parquet
+
+require tpch
+
+statement ok
+CALL dbgen(sf=1);
+
+# write lineitem partitioned by l_returnflag and l_linestatus
+statement ok
+COPY lineitem TO  '__TEST_DIR__/lineitem_partitioned' (FORMAT PARQUET, PARTITION_BY (l_returnflag, l_linestatus));
+
+statement ok
+DROP TABLE lineitem
+
+statement ok
+CREATE VIEW lineitem AS FROM '__TEST_DIR__/lineitem_partitioned/**/*.parquet'
+
+# now run tpc-h - results should be the same
+loop i 1 9
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+
+endloop

--- a/test/sql/copy/s3/hive_partitioned_write_s3.test_slow
+++ b/test/sql/copy/s3/hive_partitioned_write_s3.test_slow
@@ -24,7 +24,7 @@ require-env DUCKDB_S3_USE_SSL
 set ignore_error_messages
 
 statement ok
-pragma memory_limit='100mb'
+pragma memory_limit='200MB'
 
 statement ok
 set http_timeout=120000;


### PR DESCRIPTION
This PR reworks the hive partitioned write (i.e. `COPY` with the `PARTITION_BY` operator) so that writes are flushed to disk every 500K rows instead of waiting to flush everything at the final combine. This reduces memory usage primarily in the case where we are writing a large table to a small number of partitions. In the current implementation we would first gather all data (mostly in the temporary directory) and only then start writing to the output files. With the periodic flushing the data is instead written out to disk in a streaming fashion.

Note that while this is effective for a small number of partitions, it is much less effective for many partitions, as the individual parquet files we write will still need to gather data enough data to fill each row group. Hence memory pressure is still very high in the many-partition scenario, as if you have 10K partitions and a row group size of 120K, you could be caching up to `120K*10K` rows per-thread in-memory. A potential work-around for that is to reduce the row-group size. 

Below are some timings for the query over the full `hits` data set (100M rows, 14GB source file, ~80GB in CSV format) writing out to 10 partitions:

```sql
copy (select CounterID%10 as partition_key, * from '~/Data/hits.parquet')
TO 'hits_partitioned' (FORMAT PARQUET, PARTITION_BY partition_key);
```

| Version | 52GB memory limit, no temp dir | 52GB memory limit, temp dir |
|---------|--------------------------------|-----------------------------|
| v0.10.0 | OOM                            | 212s                        |
| New     | 53s                            | 53s                         |

