### PR TITLE
Add callbacks for newly added connections, and allow extensions to rebind queries as a result of planning failures

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -56,6 +56,7 @@ if (NOT MINGW)
             DONT_LINK
             GIT_URL https://github.com/duckdb/postgres_scanner
             GIT_TAG 883a8f1a8a487264855a5166f7df1f46ad386434
+            APPLY_PATCHES
             )
 endif()
 

--- a/.github/patches/extensions/postgres_scanner/rebind.patch
+++ b/.github/patches/extensions/postgres_scanner/rebind.patch
@@ -1,0 +1,101 @@
+diff --git a/src/include/postgres_scanner.hpp b/src/include/postgres_scanner.hpp
+index 396664d..eb8f621 100644
+--- a/src/include/postgres_scanner.hpp
++++ b/src/include/postgres_scanner.hpp
+@@ -83,6 +83,7 @@ public:
+ 	PostgresClearCacheFunction();
+ 
+ 	static void ClearCacheOnSetting(ClientContext &context, SetScope scope, Value &parameter);
++	static void ClearPostgresCaches(ClientContext &context);
+ };
+ 
+ class PostgresQueryFunction : public TableFunction {
+diff --git a/src/postgres_extension.cpp b/src/postgres_extension.cpp
+index 81bd46e..6e18d5a 100644
+--- a/src/postgres_extension.cpp
++++ b/src/postgres_extension.cpp
+@@ -12,9 +12,44 @@
+ #include "duckdb/main/attached_database.hpp"
+ #include "storage/postgres_catalog.hpp"
+ #include "storage/postgres_optimizer.hpp"
++#include "duckdb/planner/extension_callback.hpp"
++#include "duckdb/main/client_context.hpp"
++#include "duckdb/main/client_context_state.hpp"
++#include "duckdb/main/connection_manager.hpp"
++#include "duckdb/common/error_data.hpp"
+ 
+ using namespace duckdb;
+ 
++class PostgresExtensionState : public ClientContextState {
++public:
++	bool CanRequestRebind() override {
++		return true;
++	}
++	RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) override {
++		if (error.Type() != ExceptionType::BINDER) {
++			return RebindQueryInfo::DO_NOT_REBIND;
++		}
++		auto &extra_info = error.ExtraInfo();
++		auto entry = extra_info.find("error_subtype");
++		if (entry == extra_info.end()) {
++			return RebindQueryInfo::DO_NOT_REBIND;
++		}
++		if (entry->second != "COLUMN_NOT_FOUND") {
++			return RebindQueryInfo::DO_NOT_REBIND;
++		}
++		// clear caches and rebind
++		PostgresClearCacheFunction::ClearPostgresCaches(context);
++		return RebindQueryInfo::ATTEMPT_TO_REBIND;
++	}
++};
++
++class PostgresExtensionCallback : public ExtensionCallback {
++public:
++	void OnConnectionOpened(ClientContext &context) override {
++		context.registered_state.insert(make_pair("postgres_extension", make_shared<PostgresExtensionState>()));
++	}
++};
++
+ static void SetPostgresConnectionLimit(ClientContext &context, SetScope scope, Value &parameter) {
+ 	if (scope == SetScope::LOCAL) {
+ 		throw InvalidInputException("pg_connection_limit can only be set globally");
+@@ -78,6 +113,11 @@ static void LoadInternal(DatabaseInstance &db) {
+ 	OptimizerExtension postgres_optimizer;
+ 	postgres_optimizer.optimize_function = PostgresOptimizer::Optimize;
+ 	config.optimizer_extensions.push_back(std::move(postgres_optimizer));
++
++	config.extension_callbacks.push_back(make_uniq<PostgresExtensionCallback>());
++	for(auto &connection : ConnectionManager::Get(db).GetConnectionList()) {
++		connection->registered_state.insert(make_pair("postgres_extension", make_shared<PostgresExtensionState>()));
++	}
+ }
+ 
+ void PostgresScannerExtension::Load(DuckDB &db) {
+diff --git a/src/storage/postgres_clear_cache.cpp b/src/storage/postgres_clear_cache.cpp
+index 33a4789..3e16e48 100644
+--- a/src/storage/postgres_clear_cache.cpp
++++ b/src/storage/postgres_clear_cache.cpp
+@@ -21,7 +21,7 @@ static unique_ptr<FunctionData> ClearCacheBind(ClientContext &context, TableFunc
+ 	return std::move(result);
+ }
+ 
+-static void ClearPostgresCaches(ClientContext &context) {
++void PostgresClearCacheFunction::ClearPostgresCaches(ClientContext &context) {
+ 	auto databases = DatabaseManager::Get(context).GetDatabases(context);
+ 	for (auto &db_ref : databases) {
+ 		auto &db = db_ref.get();
+@@ -38,12 +38,12 @@ static void ClearCacheFunction(ClientContext &context, TableFunctionInput &data_
+ 	if (data.finished) {
+ 		return;
+ 	}
+-	ClearPostgresCaches(context);
++	PostgresClearCacheFunction::ClearPostgresCaches(context);
+ 	data.finished = true;
+ }
+ 
+ void PostgresClearCacheFunction::ClearCacheOnSetting(ClientContext &context, SetScope scope, Value &parameter) {
+-	ClearPostgresCaches(context);
++	PostgresClearCacheFunction::ClearPostgresCaches(context);
+ }
+ 
+ PostgresClearCacheFunction::PostgresClearCacheFunction()

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -254,6 +254,10 @@ private:
 	template <class T>
 	unique_ptr<T> ErrorResult(ErrorData error, const string &query = string());
 
+	shared_ptr<PreparedStatementData>
+	CreatePreparedStatementInternal(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
+	                                optional_ptr<case_insensitive_map_t<Value>> values);
+
 private:
 	//! Lock on using the ClientContext in parallel
 	mutex context_lock;

--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -12,7 +12,11 @@
 
 namespace duckdb {
 class ClientContext;
+class ErrorData;
 class MetaTransaction;
+class SQLStatement;
+
+enum class RebindQueryInfo { DO_NOT_REBIND, ATTEMPT_TO_REBIND };
 
 //! ClientContextState is virtual base class for ClientContext-local (or Query-Local, using QueryEnd callback) state
 //! e.g. caches that need to live as long as a ClientContext or Query.
@@ -31,6 +35,12 @@ public:
 	virtual void TransactionCommit(MetaTransaction &transaction, ClientContext &context) {
 	}
 	virtual void TransactionRollback(MetaTransaction &transaction, ClientContext &context) {
+	}
+	virtual bool CanRequestRebind() {
+		return false;
+	}
+	virtual RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) {
+		return RebindQueryInfo::DO_NOT_REBIND;
 	}
 };
 

--- a/src/include/duckdb/planner/extension_callback.hpp
+++ b/src/include/duckdb/planner/extension_callback.hpp
@@ -18,6 +18,12 @@ public:
 	virtual ~ExtensionCallback() {
 	}
 
+	//! Called when a new connection is opened
+	virtual void OnConnectionOpened(ClientContext &context) {
+	}
+	//! Called when a connection is closed
+	virtual void OnConnectionClosed(ClientContext &context) {
+	}
 	//! Called after an extension is finished loading
 	virtual void OnExtensionLoaded(DatabaseInstance &db, const string &name) {
 	}

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -58,6 +58,9 @@ public:
 	optional_ptr<AttachedDatabase> ModifiedDatabase() {
 		return modified_database;
 	}
+	const vector<reference<AttachedDatabase>> &OpenedTransactions() const {
+		return all_transactions
+	}
 
 private:
 	//! Lock to prevent all_transactions and transactions from getting out of sync

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -59,7 +59,7 @@ public:
 		return modified_database;
 	}
 	const vector<reference<AttachedDatabase>> &OpenedTransactions() const {
-		return all_transactions
+		return all_transactions;
 	}
 
 private:

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -374,7 +374,6 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 				auto info = s.second->OnPlanningError(*this, *statement, error);
 				if (info == RebindQueryInfo::ATTEMPT_TO_REBIND) {
 					rebind = true;
-					break;
 				}
 			}
 			if (!rebind) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -292,8 +292,9 @@ static bool IsExplainAnalyze(SQLStatement *statement) {
 }
 
 shared_ptr<PreparedStatementData>
-ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
-                                       optional_ptr<case_insensitive_map_t<Value>> values) {
+ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock, const string &query,
+                                               unique_ptr<SQLStatement> statement,
+                                               optional_ptr<case_insensitive_map_t<Value>> values) {
 	StatementType statement_type = statement->type;
 	auto result = make_shared<PreparedStatementData>(statement_type);
 
@@ -348,6 +349,41 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 #endif
 	result->plan = std::move(physical_plan);
 	return result;
+}
+
+shared_ptr<PreparedStatementData>
+ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
+                                       optional_ptr<case_insensitive_map_t<Value>> values) {
+	// check if any client context state could request a rebind
+	bool can_request_rebind = false;
+	for (auto const &s : registered_state) {
+		if (s.second->CanRequestRebind()) {
+			can_request_rebind = true;
+			break;
+		}
+	}
+	if (can_request_rebind) {
+		// if any registered state can request a rebind we do the binding on a copy first
+		try {
+			return CreatePreparedStatementInternal(lock, query, statement->Copy(), values);
+		} catch (std::exception &ex) {
+			ErrorData error(ex);
+			// check if any registered client context state wants to try a rebind
+			bool rebind = false;
+			for (auto const &s : registered_state) {
+				auto info = s.second->OnPlanningError(*this, *statement, error);
+				if (info == RebindQueryInfo::ATTEMPT_TO_REBIND) {
+					rebind = true;
+					break;
+				}
+			}
+			if (!rebind) {
+				throw;
+			}
+		}
+	}
+	// an extension wants to do a rebind - do it once
+	return CreatePreparedStatementInternal(lock, query, std::move(statement), values);
 }
 
 QueryProgress ClientContext::GetQueryProgress() {
@@ -446,7 +482,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 				invalidate_transaction = true;
 			} else {
 				// Interrupted by an exception caused in a worker thread
-				auto error = executor.GetError();
+				error = executor.GetError();
 				invalidate_transaction = Exception::InvalidatesTransaction(error.Type());
 				result.SetError(error);
 			}


### PR DESCRIPTION
This PR adds two new callbacks to the `ExtensionCallback` class that can be used to keep track of newly added connections:

```cpp
//! Called when a new connection is opened
virtual void OnConnectionOpened(ClientContext &context) {
}
//! Called when a connection is closed
virtual void OnConnectionClosed(ClientContext &context) {
}
```

In addition, we add new callbacks to the `ClientContextState`:

```cpp
virtual bool CanRequestRebind() {
	return false;
}
virtual RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) {
	return RebindQueryInfo::DO_NOT_REBIND;
}
```

If `CanRequestRebind` returns true, the `OnPlanningError` is called when an error is encountered during the binding/planning process. An extension can then return `RebindQueryInfo::ATTEMPT_TO_REBIND` in order to trigger a rebind of the query.

A POC of this functionality is added to the Postgres scanner in the patch that is also part of the PR. In this POC, we check if the encountered error is a "column not found" error. If it is - we clear the Postgres caches and retry the binding process. This makes it so that we can retry if columns are added to a table in Postgres which has caused our caches to become invalid. For example, the following now fully works:

```sql
-- in DuckDB
ATTACH 'postgres:dbname=postgres' AS pgdb;
select * from pgdb.new_tbl;
┌────────┐
│   i    │
│ int32  │
├────────┤
│ 0 rows │
└────────┘
select j from pgdb.new_tbl;
-- Binder Error: Referenced column "j" not found in FROM clause!


-- now in Postgres
postgres> alter table new_tbl add column j int;

-- now in DuckDB
select j from pgdb.new_tbl;
┌────────┐
│   j    │
│ int32  │
├────────┤
│ 0 rows │
└────────┘
```

Previously, the stale cache information had to be cleared manually either by re-opening the database or by calling `pg_clear_cache()`.